### PR TITLE
Add CoreAudio backend for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,12 @@ if(ANDROID)
 elseif(WIN32)
   target_compile_definitions(mousiki PRIVATE MUISC_PLATFORM_WINDOWS=1 MA_ENABLE_ONLY_SPECIFIC_BACKENDS=1 MA_ENABLE_WASAPI=1)
   target_link_libraries(mousiki PRIVATE ole32 winmm)
+elseif(APPLE)
+  # miniaudio links CoreAudio at runtime via dlopen, so no -framework flags
+  # are needed here. All backends stay compiled in; the runtime picks
+  # ma_backend_coreaudio (see audio_backend.cpp).
+  target_compile_definitions(mousiki PRIVATE MUISC_PLATFORM_MACOS=1)
+  target_link_libraries(mousiki PRIVATE dl m)
 elseif(UNIX AND NOT APPLE)
   target_compile_definitions(mousiki PRIVATE MUISC_PLATFORM_LINUX=1 MA_ENABLE_ONLY_SPECIFIC_BACKENDS=1 MA_ENABLE_PULSEAUDIO=1 MA_ENABLE_ALSA=1)
   # Note: miniaudio talks to PipeWire through its PulseAudio *and* ALSA

--- a/src/audio_backend.cpp
+++ b/src/audio_backend.cpp
@@ -10,6 +10,8 @@ bool init_platform_audio_context(ma_context& out_context) {
     ma_backend backends[] = { ma_backend_wasapi };
 #elif defined(MUISC_PLATFORM_LINUX)
     ma_backend backends[] = { ma_backend_pulseaudio, ma_backend_alsa };
+#elif defined(MUISC_PLATFORM_MACOS)
+    ma_backend backends[] = { ma_backend_coreaudio };
 #else
     ma_backend backends[] = { ma_backend_null };
 #endif
@@ -26,6 +28,8 @@ const char* platform_backend_name() {
     return "WASAPI (Windows)";
 #elif defined(MUISC_PLATFORM_LINUX)
     return "PulseAudio/ALSA -> PipeWire (Linux)";
+#elif defined(MUISC_PLATFORM_MACOS)
+    return "CoreAudio (macOS)";
 #else
     return "null";
 #endif


### PR DESCRIPTION
## Summary

The README lists macOS as unverified. I built and ran mousiki on macOS and found that it launches fine but plays silence: `init_platform_audio_context()` has no Apple branch, so the build falls through to `#else` and picks `ma_backend_null`.

This PR adds the missing branch:

- **CMakeLists.txt**: new `elseif(APPLE)` block defining `MUISC_PLATFORM_MACOS=1`, following the existing per-platform pattern. No `-framework` flags are needed because miniaudio dlopens CoreAudio at runtime, so all backends stay compiled in as before.
- **src/audio_backend.cpp**: select `ma_backend_coreaudio` and report `"CoreAudio (macOS)"` when `MUISC_PLATFORM_MACOS` is defined.

## Testing

- macOS 26 (Darwin 25.6.0), Apple Silicon, Apple clang, CMake from Homebrew.
- `cmake -S . -B build && cmake --build build` completes with no warnings from the project sources.
- Local files and `/s:` YouTube streaming both produce audio through the default output device.
- Synced lyrics also work once `MOUSIKI_SCRIPTS_DIR` is set, since `readlink("/proc/self/exe")` in `find_lyrics_script()` does not exist on macOS. Left out of this PR to keep it focused; happy to follow up with `_NSGetExecutablePath` if you want it.

With this change macOS could probably move from "unverified" to supported in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
